### PR TITLE
Add TypedDate typealiases for various date components

### DIFF
--- a/Sources/TypedDate/TypedDateOf.swift
+++ b/Sources/TypedDate/TypedDateOf.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+public typealias TypedDateOfYear = TypedDate<Year>
+public typealias TypedDateOfMonth = TypedDate<(Year, Month)>
+public typealias TypedDateOfDay = TypedDate<(Year, Month, Day)>
+public typealias TypedDateOfHour = TypedDate<(Year, Month, Day, Hour)>
+public typealias TypedDateOfMinute = TypedDate<(Year, Month, Day, Hour, Minute)>
+public typealias TypedDateOfSecond = TypedDate<(Year, Month, Day, Hour, Minute, Second)>
+public typealias TypedDateOfNanosecond = TypedDate<(Year, Month, Day, Hour, Minute, Second, Nanosecond)>


### PR DESCRIPTION
When specifying up to nanoseconds or seconds in TypedDate, writing out the full type names can be quite cumbersome. To simplify this, I have added typealiases like TypedDateOfYear and TypedDateOfNanosecond to make the usage more concise and user-friendly.

```Swift
let date1: TypedDate<(Year, Month, Day, Hour, Minute, Second, Nanosecond)>
let date2: TypedDateOfNanosecond

// date1 and date2 have the same type
```