### PR TITLE
Update swift-syntax dependency to version 600

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -37,15 +37,6 @@
       }
     },
     {
-      "identity" : "swift-testing",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-testing.git",
-      "state" : {
-        "revision" : "399f76dcd91e4c688ca2301fa24a8cc6d9927211",
-        "version" : "0.99.0"
-      }
-    },
-    {
       "identity" : "xctest-dynamic-overlay",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/xctest-dynamic-overlay",

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,12 +1,21 @@
 {
   "pins" : [
     {
+      "identity" : "swift-custom-dump",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-custom-dump",
+      "state" : {
+        "revision" : "82645ec760917961cfa08c9c0c7104a57a0fa4b1",
+        "version" : "1.3.3"
+      }
+    },
+    {
       "identity" : "swift-macro-testing",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-macro-testing",
       "state" : {
-        "revision" : "35acd9468d40ae87e75991a18af6271e8124c261",
-        "version" : "0.2.1"
+        "revision" : "9ab11325daa51c7c5c10fcf16c92bac906717c7e",
+        "version" : "0.6.4"
       }
     },
     {
@@ -14,8 +23,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-snapshot-testing",
       "state" : {
-        "revision" : "bb0ea08db8e73324fe6c3727f755ca41a23ff2f4",
-        "version" : "1.14.2"
+        "revision" : "a8b7c5e0ed33d8ab8887d1654d9b59f2cbad529b",
+        "version" : "1.18.7"
       }
     },
     {
@@ -23,8 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-syntax.git",
       "state" : {
-        "revision" : "6ad4ea24b01559dde0773e3d091f1b9e36175036",
-        "version" : "509.0.2"
+        "revision" : "0687f71944021d616d34d922343dcef086855920",
+        "version" : "600.0.1"
       }
     },
     {
@@ -32,8 +41,17 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-testing.git",
       "state" : {
-        "revision" : "395288f1d154d0e8b92823313957546ddb88106c",
-        "version" : "0.1.0"
+        "revision" : "399f76dcd91e4c688ca2301fa24a8cc6d9927211",
+        "version" : "0.99.0"
+      }
+    },
+    {
+      "identity" : "xctest-dynamic-overlay",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/xctest-dynamic-overlay",
+      "state" : {
+        "revision" : "4c27acf5394b645b70d8ba19dc249c0472d5f618",
+        "version" : "1.7.0"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -23,7 +23,6 @@ let package = Package(
     dependencies: [
         // Depend on the Swift 6.0 release of SwiftSyntax
         .package(url: "https://github.com/apple/swift-syntax.git", from: "600.0.0"),
-        .package(url: "https://github.com/apple/swift-testing.git", from: "0.1.0"),
         .package(url: "https://github.com/pointfreeco/swift-macro-testing", from: "0.2.1")
     ],
     targets: [
@@ -67,7 +66,6 @@ let package = Package(
             name: "TypedDateTests",
             dependencies: [
                 "TypedDate",
-                .product(name: "Testing", package: "swift-testing"),
             ]
         )
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -21,8 +21,8 @@ let package = Package(
         )
     ],
     dependencies: [
-        // Depend on the Swift 5.9 release of SwiftSyntax
-        .package(url: "https://github.com/apple/swift-syntax.git", "509.0.0"..<"510.0.0"),
+        // Depend on the Swift 6.0 release of SwiftSyntax
+        .package(url: "https://github.com/apple/swift-syntax.git", from: "600.0.0"),
         .package(url: "https://github.com/apple/swift-testing.git", from: "0.1.0"),
         .package(url: "https://github.com/pointfreeco/swift-macro-testing", from: "0.2.1")
     ],

--- a/Sources/TypedDateMacros/EraseContextMacro.swift
+++ b/Sources/TypedDateMacros/EraseContextMacro.swift
@@ -28,7 +28,7 @@ package struct EraseContextMacro: MemberMacro {
         }
 
         return [
-            try generateEraseContext(of: baseComponents).cast(DeclSyntax.self),
+            DeclSyntax(try generateEraseContext(of: baseComponents)),
         ]
     }
 

--- a/Sources/TypedDateMacros/FillInContextMacro.swift
+++ b/Sources/TypedDateMacros/FillInContextMacro.swift
@@ -28,7 +28,7 @@ package struct FillInContextMacro: MemberMacro {
         }
 
         return [
-            try generateFillContext(of: baseComponents).cast(DeclSyntax.self),
+            DeclSyntax(try generateFillContext(of: baseComponents)),
         ]
     }
 

--- a/Sources/TypedDateMacros/ModifyContextMacro.swift
+++ b/Sources/TypedDateMacros/ModifyContextMacro.swift
@@ -28,7 +28,7 @@ package struct ModifyContextMacro: MemberMacro {
         }
 
         return [
-            try generateModifyContext(of: baseComponents).cast(DeclSyntax.self),
+            DeclSyntax(try generateModifyContext(of: baseComponents)),
         ]
     }
 

--- a/Tests/TypedDateMacrosTests/EraseContextMacroTests.swift
+++ b/Tests/TypedDateMacrosTests/EraseContextMacroTests.swift
@@ -38,7 +38,8 @@ final class EraseContextMacroTests: XCTestCase {
                 minute = (TypedDate<(Year, Month, Day, Hour, Minute)>.self, (base.0, base.1, base.2, base.3, base.4))
                 second = (TypedDate<(Year, Month, Day, Hour, Minute, Second)>.self, (base.0, base.1, base.2, base.3, base.4, base.5))
                     }
-                }}
+                }
+            }
             """
         }
     }
@@ -68,7 +69,8 @@ final class EraseContextMacroTests: XCTestCase {
                 hour = (TypedDate<(Year, Month, Day, Hour)>.self, (base.0, base.1, base.2, base.3))
                 minute = (TypedDate<(Year, Month, Day, Hour, Minute)>.self, (base.0, base.1, base.2, base.3, base.4))
                     }
-                }}
+                }
+            }
             """
         }
     }
@@ -96,7 +98,8 @@ final class EraseContextMacroTests: XCTestCase {
                 day = (TypedDate<(Year, Month, Day)>.self, (base.0, base.1, base.2))
                 hour = (TypedDate<(Year, Month, Day, Hour)>.self, (base.0, base.1, base.2, base.3))
                     }
-                }}
+                }
+            }
             """
         }
     }
@@ -121,7 +124,8 @@ final class EraseContextMacroTests: XCTestCase {
                 month = (TypedDate<(Year, Month)>.self, (base.0, base.1))
                 day = (TypedDate<(Year, Month, Day)>.self, (base.0, base.1, base.2))
                     }
-                }}
+                }
+            }
             """
         }
     }
@@ -144,7 +148,8 @@ final class EraseContextMacroTests: XCTestCase {
                 year = (TypedDate<Year>.self, base.0)
                 month = (TypedDate<(Year, Month)>.self, (base.0, base.1))
                     }
-                }}
+                }
+            }
             """
         }
     }
@@ -165,7 +170,8 @@ final class EraseContextMacroTests: XCTestCase {
                         self.base = base
                 year = (TypedDate<Year>.self, base.0)
                     }
-                }}
+                }
+            }
             """
         }
     }

--- a/Tests/TypedDateMacrosTests/FillInContextMacroTests.swift
+++ b/Tests/TypedDateMacrosTests/FillInContextMacroTests.swift
@@ -28,7 +28,8 @@ final class FillInContextMacroTests: XCTestCase {
                         self.base = base
                 nanosecond = { data in (base.0, base.1, base.2, base.3, base.4, base.5, data) }
                     }
-                }}
+                }
+            }
             """
         }
     }
@@ -52,7 +53,8 @@ final class FillInContextMacroTests: XCTestCase {
                 second = { data in (base.0, base.1, base.2, base.3, base.4, data) }
                 nanosecond = { data in (base.0, base.1, base.2, base.3, base.4, data.0, data.1) }
                     }
-                }}
+                }
+            }
             """
         }
     }
@@ -77,7 +79,8 @@ final class FillInContextMacroTests: XCTestCase {
                 second = { data in (base.0, base.1, base.2, base.3, data.0, data.1) }
                 nanosecond = { data in (base.0, base.1, base.2, base.3, data.0, data.1, data.2) }
                     }
-                }}
+                }
+            }
             """
         }
     }
@@ -104,7 +107,8 @@ final class FillInContextMacroTests: XCTestCase {
                 second = { data in (base.0, base.1, base.2, data.0, data.1, data.2) }
                 nanosecond = { data in (base.0, base.1, base.2, data.0, data.1, data.2, data.3) }
                     }
-                }}
+                }
+            }
             """
         }
     }
@@ -133,7 +137,8 @@ final class FillInContextMacroTests: XCTestCase {
                 second = { data in (base.0, base.1, data.0, data.1, data.2, data.3) }
                 nanosecond = { data in (base.0, base.1, data.0, data.1, data.2, data.3, data.4) }
                     }
-                }}
+                }
+            }
             """
         }
     }
@@ -165,7 +170,8 @@ final class FillInContextMacroTests: XCTestCase {
                 second = { data in (base, data.0, data.1, data.2, data.3, data.4) }
                 nanosecond = { data in (base, data.0, data.1, data.2, data.3, data.4, data.5) }
                     }
-                }}
+                }
+            }
             """
         }
     }

--- a/Tests/TypedDateMacrosTests/ModifyContextMacroTests.swift
+++ b/Tests/TypedDateMacrosTests/ModifyContextMacroTests.swift
@@ -40,7 +40,8 @@ final class ModifyContextMacroTests: XCTestCase {
                 self.second = (base.5, { second in (base.0, base.1, base.2, base.3, base.4, second, base.6) })
                 self.nanosecond = (base.6, { nanosecond in (base.0, base.1, base.2, base.3, base.4, base.5, nanosecond) })
                     }
-                }}
+                }
+            }
             """
         }
     }
@@ -72,7 +73,8 @@ final class ModifyContextMacroTests: XCTestCase {
                 self.minute = (base.4, { minute in (base.0, base.1, base.2, base.3, minute, base.5) })
                 self.second = (base.5, { second in (base.0, base.1, base.2, base.3, base.4, second) })
                     }
-                }}
+                }
+            }
             """
         }
     }
@@ -102,7 +104,8 @@ final class ModifyContextMacroTests: XCTestCase {
                 self.hour = (base.3, { hour in (base.0, base.1, base.2, hour, base.4) })
                 self.minute = (base.4, { minute in (base.0, base.1, base.2, base.3, minute) })
                     }
-                }}
+                }
+            }
             """
         }
     }
@@ -130,7 +133,8 @@ final class ModifyContextMacroTests: XCTestCase {
                 self.day = (base.2, { day in (base.0, base.1, day, base.3) })
                 self.hour = (base.3, { hour in (base.0, base.1, base.2, hour) })
                     }
-                }}
+                }
+            }
             """
         }
     }
@@ -156,7 +160,8 @@ final class ModifyContextMacroTests: XCTestCase {
                 self.month = (base.1, { month in (base.0, month, base.2) })
                 self.day = (base.2, { day in (base.0, base.1, day) })
                     }
-                }}
+                }
+            }
             """
         }
     }
@@ -180,7 +185,8 @@ final class ModifyContextMacroTests: XCTestCase {
                 self.year = (base.0, { year in (year, base.1) })
                 self.month = (base.1, { month in (base.0, month) })
                     }
-                }}
+                }
+            }
             """
         }
     }
@@ -202,7 +208,8 @@ final class ModifyContextMacroTests: XCTestCase {
                         self.base = base
                 self.year = (base, { year in (year) })
                     }
-                }}
+                }
+            }
             """
         }
     }

--- a/Tests/TypedDateTests/Scaffolding.swift
+++ b/Tests/TypedDateTests/Scaffolding.swift
@@ -1,8 +1,0 @@
-import Testing
-import XCTest
-
-final class AllTests: XCTestCase {
-    func testAll() async {
-        await XCTestScaffold.runAllTests(hostedBy: self)
-    }
-}


### PR DESCRIPTION
Update swift-syntax from 509.x to 600.0.0 and update related comments to Swift 6.0